### PR TITLE
Fix the failing docker logs command for the agent container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,15 @@ agent:
 	echo "API-Token: ${API_TOKEN}"
 	./scripts/jenkins-wait.sh Jenkins/job/Setup
 	sleep 30
-	curl http://admin:$(API_TOKEN)@localhost:8080/computer/docker-1/slave-agent.jnlp
 	docker run -d --name agent --rm $(IMAGE) -url http://$(JOCKER_HOST):8080 $(shell curl -L -s http://admin:$(API_TOKEN)@localhost:8080/computer/docker-1/slave-agent.jnlp | sed "s/.*<application-desc main-class=\"hudson.remoting.jnlp.Main\"><argument>\([a-z0-9]*\).*/\1/") docker-1
-	docker logs $(shell docker ps -a -f name=agent -q)
+	curl http://admin:$(API_TOKEN)@localhost:8080/computer/docker-1/slave-agent.jnlp
+	docker logs `docker ps -a -q -f name=agent`
 
 test:
 	docker ps -a
 	docker logs $(shell docker ps -a -f name=jocker -q)
 	docker ps -a
-	docker logs $(shell docker ps -a -f name=agent -q) || true
+	docker logs `docker ps -a -q -f name=agent`
 	./scripts/jenkins-wait.sh Jenkins/job/Setup
 	@curl -s http://admin:$(API_TOKEN)@localhost:8080/job/Jenkins/job/SharedLib/lastBuild/consoleText
 	@curl -s http://admin:$(API_TOKEN)@localhost:8080/job/Jenkins/job/Configure/lastBuild/consoleText
@@ -41,6 +41,6 @@ test:
 	@curl -s http://admin:$(API_TOKEN)@localhost:8080/job/Jenkins/job/Setup/lastBuild/consoleText
 	@curl -s http://admin:$(API_TOKEN)@localhost:8080/job/Jenkins/job/Setup/lastBuild/api/json | jq -r .result | grep SUCCESS
 
-	docker logs $(shell docker ps -a -f name=agent -q)
+	docker logs `docker ps -a -q -f name=agent`
 	./scripts/jenkins-cli.sh pulumi $(API_TOKEN)
 	@curl -s http://admin:$(API_TOKEN)@localhost:8080/job/pulumi/lastBuild/api/json | jq -r .result | grep SUCCESS


### PR DESCRIPTION
The shell command in the Makefile doesn't work for the docker ps
command . It can't retrieve the container id and then not show the log
either.